### PR TITLE
feat: `prerelease_label` can be set at runtime with `--prerelease-label` or `KNOPE_PRERELEASE_LABEL`.

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,7 +23,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_push_gpgsign: false
-      - run: |
-          cargo run -- prerelease
+      - run: cargo run -- release --prerelease-label=rc
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ platform-dirs = "0.3.0"
 git-conventional = "0.12.0"
 ureq = { version = "2.5.0", features = ["json"] }
 http = "0.2.8"
-clap = { version = "3.2.17", features = ["cargo", "derive"] }
+clap = { version = "3.2.17", features = ["cargo", "derive", "env"] }
 itertools = "0.10.3"
 miette = { version = "5.3.0", features = ["fancy"] }
 thiserror = "1.0.32"

--- a/docs/src/config/step/PrepareRelease.md
+++ b/docs/src/config/step/PrepareRelease.md
@@ -31,6 +31,8 @@ type = "PrepareRelease"
 prerelease_label = "rc"
 ```
 
+If your prerelease workflow is exactly like your release workflow, you can instead temporarily add a prerelease label by passing the `--prerelease-label` option to `knope` or by setting the `KNOPE_PRERELEASE_LABEL` environment variable. This option overrides any set `prerelease_label` for any workflow run.
+
 ### Going from Pre-release to Full Release
 
 Let's say that in addition to the configuration from the above example, you also have a section like this:

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -21,6 +21,14 @@ There are a few options you can pass to `knope` to control how it behaves.
 3. `--generate` will generate a `knope.toml` file in the current directory.
 4. `--validate` will check your `knope.toml` to make sure every workflow in it is valid, then exit. This could be useful to run in CI to make sure that your config is always valid. The exit code of this command will be 0 only if the config is valid.
 5. `--dry-run` will pretend to run the selected workflow (either via arg or prompt), but will not actually perform any work (e.g., external commands, file I/O, API calls). Detects the same errors as `--validate` but also outputs info about what _would_ happen to stdout.
+6. `--prerelease-label` will override the `prerelease_label` for any [`PrepareRelease`] step run.
+
+### Environment Variables
+
+These are all the environment variables that Knope will look for when running workflows.
+
+1. `KNOPE_PRERELEASE_LABEL` works just like the `--prerelease-label` option. Note that the option takes precedence over the environment variable.
+2. `GITHUB_TOKEN` will be used to load credentials from GitHub for [GitHub config].
 
 ## Features
 
@@ -39,3 +47,5 @@ You define a [config] file named `knope.toml` which has some metadata (e.g. Jira
 [config]: config/config.md
 [workflow]: config/workflow.md
 [step]: config/step/step.md
+[`preparerelease`]: config/step/PrepareRelease.md
+[github config]: config/github.md

--- a/knope.toml
+++ b/knope.toml
@@ -48,37 +48,6 @@ command = "git push"
 [[workflows.steps]]
 type = "Release"
 
-[[workflows]]
-name = "prerelease"
-
-[[workflows.steps]]
-type = "PrepareRelease"
-prerelease_label = "rc"
-
-[[workflow.steps]]
-type = "Command"
-command = "cargo update -w"
-
-[[workflows.steps]]
-type = "Command"
-command = "npx -y prettier **/*.md --write"
-
-[[workflows.steps]]
-type = "Command"
-command = "git add Cargo.toml Cargo.lock CHANGELOG.md"
-
-[[workflows.steps]]
-type = "Command"
-command = "git commit -m \"chore: Bump to version\""
-variables = { "version" = "Version" }
-
-[[workflows.steps]]
-type = "Command"
-command = "git push"
-
-[[workflows.steps]]
-type = "Release"
-
 [github]
 owner = "knope-dev"
 repo = "knope"

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,13 @@ impl Config {
             .into_diagnostic()
             .wrap_err("Invalid TOML when parsing config")
     }
+
+    /// Set the prerelease label for all `PrepareRelease` steps in all workflows in `self`.
+    pub(crate) fn set_prerelease_label(&mut self, label: &str) {
+        for workflow in &mut self.workflows {
+            workflow.set_prerelease_label(label);
+        }
+    }
 }
 
 /// Generate a brand new config file for the project in the current directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,10 @@ pub fn run(cli: Cli) -> Result<()> {
 
     let preselected_workflow = cli.workflow;
 
-    let config = Config::load()?;
+    let mut config = Config::load()?;
+    if let Some(prerelease_label) = cli.prerelease_label {
+        config.set_prerelease_label(&prerelease_label);
+    }
     let state = State::new(config.jira, config.github, config.packages);
 
     if cli.validate {
@@ -99,6 +102,10 @@ pub struct Cli {
     #[clap(long)]
     /// Generate a new `knope.toml` file.
     generate: bool,
+
+    #[clap(long, env = "KNOPE_PRERELEASE_LABEL")]
+    /// Set the `prerelease_label` attribute of any `PrepareRelease` steps at runtime.
+    prerelease_label: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/step.rs
+++ b/src/step.rs
@@ -96,6 +96,13 @@ impl Step {
             Step::Release => releases::release(run_type),
         }
     }
+
+    /// Set `prerelease_label` if `self` is `PrepareRelease`.
+    pub(crate) fn set_prerelease_label(&mut self, prerelease_label: &str) {
+        if let Step::PrepareRelease(prepare_release) = self {
+            prepare_release.prerelease_label = Some(String::from(prerelease_label));
+        }
+    }
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -19,6 +19,15 @@ pub(crate) struct Workflow {
     pub(crate) steps: Vec<Step>,
 }
 
+impl Workflow {
+    /// Set `prerelease_label` for any steps that are `PrepareRelease` steps.
+    pub(crate) fn set_prerelease_label(&mut self, prerelease_label: &str) {
+        for step in &mut self.steps {
+            step.set_prerelease_label(prerelease_label);
+        }
+    }
+}
+
 /// A collection of errors from running with the `--validate` option.
 #[derive(Debug, Error, Diagnostic)]
 #[error("There are problems with the defined workflows")]

--- a/tests/prepare_release.rs
+++ b/tests/prepare_release.rs
@@ -57,6 +57,210 @@ fn prerelease_after_release() {
     );
 }
 
+/// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but change
+/// the configured `prerelease_label` at runtime using the `--prerelease-label` argument.
+#[test]
+fn override_prerelease_label_with_option() {
+    // Arrange.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/prepare_release/override_prerelease_label");
+
+    init(temp_path);
+    commit(temp_path, "Initial commit");
+    tag(temp_path, "v1.0.0");
+    commit(temp_path, "feat: New feature in existing release");
+    tag(temp_path, "v1.1.0");
+    commit(temp_path, "feat!: Breaking feature in new RC");
+
+    for file in ["knope.toml", "CHANGELOG.md", "Cargo.toml"] {
+        copy(source_path.join(file), temp_path.join(file)).unwrap();
+    }
+
+    // Act.
+    let assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .arg("--prerelease-label=alpha")
+        .current_dir(temp_dir.path())
+        .assert();
+    let dry_run_assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .arg("--prerelease-label=alpha")
+        .arg("--dry-run")
+        .current_dir(temp_dir.path())
+        .assert();
+
+    // Assert.
+    assert
+        .success()
+        .stdout_eq_path(source_path.join("output.txt"));
+    dry_run_assert
+        .success()
+        .stdout_eq_path(source_path.join("dry_run_output.txt"));
+
+    assert_eq_path(
+        source_path.join("EXPECTED_CHANGELOG.md"),
+        read_to_string(temp_path.join("CHANGELOG.md")).unwrap(),
+    );
+    assert_eq_path(
+        source_path.join("Expected_Cargo.toml"),
+        read_to_string(temp_path.join("Cargo.toml")).unwrap(),
+    );
+}
+
+/// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but change
+/// the configured `prerelease_label` at runtime using the `KNOPE_PRERELEASE_LABEL` environment variable.
+#[test]
+fn override_prerelease_label_with_env() {
+    // Arrange.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/prepare_release/override_prerelease_label");
+
+    init(temp_path);
+    commit(temp_path, "Initial commit");
+    tag(temp_path, "v1.0.0");
+    commit(temp_path, "feat: New feature in existing release");
+    tag(temp_path, "v1.1.0");
+    commit(temp_path, "feat!: Breaking feature in new RC");
+
+    for file in ["knope.toml", "CHANGELOG.md", "Cargo.toml"] {
+        copy(source_path.join(file), temp_path.join(file)).unwrap();
+    }
+
+    // Act.
+    let assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .env("KNOPE_PRERELEASE_LABEL", "alpha")
+        .current_dir(temp_dir.path())
+        .assert();
+    let dry_run_assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .env("KNOPE_PRERELEASE_LABEL", "alpha")
+        .arg("--dry-run")
+        .current_dir(temp_dir.path())
+        .assert();
+
+    // Assert.
+    assert
+        .success()
+        .stdout_eq_path(source_path.join("output.txt"));
+    dry_run_assert
+        .success()
+        .stdout_eq_path(source_path.join("dry_run_output.txt"));
+
+    assert_eq_path(
+        source_path.join("EXPECTED_CHANGELOG.md"),
+        read_to_string(temp_path.join("CHANGELOG.md")).unwrap(),
+    );
+    assert_eq_path(
+        source_path.join("Expected_Cargo.toml"),
+        read_to_string(temp_path.join("Cargo.toml")).unwrap(),
+    );
+}
+
+/// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but set
+/// the configured `prerelease_label` at runtime using the `--prerelease-label` argument.
+#[test]
+fn enable_prerelease_label_with_option() {
+    // Arrange.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/prepare_release/enable_prerelease");
+
+    init(temp_path);
+    commit(temp_path, "Initial commit");
+    tag(temp_path, "v1.0.0");
+    commit(temp_path, "feat: New feature in existing release");
+    tag(temp_path, "v1.1.0");
+    commit(temp_path, "feat!: Breaking feature in new RC");
+
+    for file in ["knope.toml", "CHANGELOG.md", "Cargo.toml"] {
+        copy(source_path.join(file), temp_path.join(file)).unwrap();
+    }
+
+    // Act.
+    let assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .arg("--prerelease-label=rc")
+        .current_dir(temp_dir.path())
+        .assert();
+    let dry_run_assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .arg("--prerelease-label=rc")
+        .arg("--dry-run")
+        .current_dir(temp_dir.path())
+        .assert();
+
+    // Assert.
+    assert
+        .success()
+        .stdout_eq_path(source_path.join("output.txt"));
+    dry_run_assert
+        .success()
+        .stdout_eq_path(source_path.join("dry_run_output.txt"));
+
+    assert_eq_path(
+        source_path.join("EXPECTED_CHANGELOG.md"),
+        read_to_string(temp_path.join("CHANGELOG.md")).unwrap(),
+    );
+    assert_eq_path(
+        source_path.join("Expected_Cargo.toml"),
+        read_to_string(temp_path.join("Cargo.toml")).unwrap(),
+    );
+}
+
+/// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but set
+/// the configured `prerelease_label` at runtime using the `KNOPE_PRERELEASE_LABEL` environment variable.
+#[test]
+fn enable_prerelease_label_with_env() {
+    // Arrange.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/prepare_release/enable_prerelease");
+
+    init(temp_path);
+    commit(temp_path, "Initial commit");
+    tag(temp_path, "v1.0.0");
+    commit(temp_path, "feat: New feature in existing release");
+    tag(temp_path, "v1.1.0");
+    commit(temp_path, "feat!: Breaking feature in new RC");
+
+    for file in ["knope.toml", "CHANGELOG.md", "Cargo.toml"] {
+        copy(source_path.join(file), temp_path.join(file)).unwrap();
+    }
+
+    // Act.
+    let assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .env("KNOPE_PRERELEASE_LABEL", "rc")
+        .current_dir(temp_dir.path())
+        .assert();
+    let dry_run_assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .env("KNOPE_PRERELEASE_LABEL", "rc")
+        .arg("--dry-run")
+        .current_dir(temp_dir.path())
+        .assert();
+
+    // Assert.
+    assert
+        .success()
+        .stdout_eq_path(source_path.join("output.txt"));
+    dry_run_assert
+        .success()
+        .stdout_eq_path(source_path.join("dry_run_output.txt"));
+
+    assert_eq_path(
+        source_path.join("EXPECTED_CHANGELOG.md"),
+        read_to_string(temp_path.join("CHANGELOG.md")).unwrap(),
+    );
+    assert_eq_path(
+        source_path.join("Expected_Cargo.toml"),
+        read_to_string(temp_path.join("Cargo.toml")).unwrap(),
+    );
+}
+
 /// Run a `PrepareRelease` as a pre-release in a repo which already contains a pre-release.
 #[test]
 fn second_prerelease() {

--- a/tests/prepare_release.rs
+++ b/tests/prepare_release.rs
@@ -160,7 +160,7 @@ fn override_prerelease_label_with_env() {
 }
 
 /// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but set
-/// the configured `prerelease_label` at runtime using the `--prerelease-label` argument.
+/// the `prerelease_label` at runtime using the `--prerelease-label` argument.
 #[test]
 fn enable_prerelease_label_with_option() {
     // Arrange.
@@ -211,7 +211,7 @@ fn enable_prerelease_label_with_option() {
 }
 
 /// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but set
-/// the configured `prerelease_label` at runtime using the `KNOPE_PRERELEASE_LABEL` environment variable.
+/// the `prerelease_label` at runtime using the `KNOPE_PRERELEASE_LABEL` environment variable.
 #[test]
 fn enable_prerelease_label_with_env() {
     // Arrange.
@@ -239,6 +239,62 @@ fn enable_prerelease_label_with_env() {
     let dry_run_assert = Command::new(cargo_bin!("knope"))
         .arg("prerelease")
         .env("KNOPE_PRERELEASE_LABEL", "rc")
+        .arg("--dry-run")
+        .current_dir(temp_dir.path())
+        .assert();
+
+    // Assert.
+    assert
+        .success()
+        .stdout_eq_path(source_path.join("output.txt"));
+    dry_run_assert
+        .success()
+        .stdout_eq_path(source_path.join("dry_run_output.txt"));
+
+    assert_eq_path(
+        source_path.join("EXPECTED_CHANGELOG.md"),
+        read_to_string(temp_path.join("CHANGELOG.md")).unwrap(),
+    );
+    assert_eq_path(
+        source_path.join("Expected_Cargo.toml"),
+        read_to_string(temp_path.join("Cargo.toml")).unwrap(),
+    );
+}
+
+/// Run a `PrepareRelease` as a pre-release in a repo which already contains a release, but set
+/// the `prerelease_label` at runtime using both the `--prerelease-label` argument and the
+/// `KNOPE_PRERELEASE_LABEL` environment variable.
+///
+/// The `--prerelease-label` argument should take precedence over the environment variable.
+#[test]
+fn prerelease_label_option_overrides_env() {
+    // Arrange.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/prepare_release/enable_prerelease");
+
+    init(temp_path);
+    commit(temp_path, "Initial commit");
+    tag(temp_path, "v1.0.0");
+    commit(temp_path, "feat: New feature in existing release");
+    tag(temp_path, "v1.1.0");
+    commit(temp_path, "feat!: Breaking feature in new RC");
+
+    for file in ["knope.toml", "CHANGELOG.md", "Cargo.toml"] {
+        copy(source_path.join(file), temp_path.join(file)).unwrap();
+    }
+
+    // Act.
+    let assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .env("KNOPE_PRERELEASE_LABEL", "alpha")
+        .arg("--prerelease-label=rc")
+        .current_dir(temp_dir.path())
+        .assert();
+    let dry_run_assert = Command::new(cargo_bin!("knope"))
+        .arg("prerelease")
+        .env("KNOPE_PRERELEASE_LABEL", "alpha")
+        .arg("--prerelease-label=rc")
         .arg("--dry-run")
         .current_dir(temp_dir.path())
         .assert();

--- a/tests/prepare_release/enable_prerelease/CHANGELOG.md
+++ b/tests/prepare_release/enable_prerelease/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.1.0
+
+### Features
+
+- New feature in existing release

--- a/tests/prepare_release/enable_prerelease/Cargo.toml
+++ b/tests/prepare_release/enable_prerelease/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.1.0"

--- a/tests/prepare_release/enable_prerelease/EXPECTED_CHANGELOG.md
+++ b/tests/prepare_release/enable_prerelease/EXPECTED_CHANGELOG.md
@@ -1,0 +1,11 @@
+## 2.0.0-rc.0
+
+### Breaking Changes
+
+- Breaking feature in new RC
+
+## 1.1.0
+
+### Features
+
+- New feature in existing release

--- a/tests/prepare_release/enable_prerelease/Expected_Cargo.toml
+++ b/tests/prepare_release/enable_prerelease/Expected_Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "2.0.0-rc.0"

--- a/tests/prepare_release/enable_prerelease/dry_run_output.txt
+++ b/tests/prepare_release/enable_prerelease/dry_run_output.txt
@@ -1,0 +1,8 @@
+Would bump version to 2.0.0-rc.1
+Would add the following to CHANGELOG.md: 
+## 2.0.0-rc.1
+
+### Breaking Changes
+
+- Breaking feature in new RC
+

--- a/tests/prepare_release/enable_prerelease/knope.toml
+++ b/tests/prepare_release/enable_prerelease/knope.toml
@@ -1,0 +1,9 @@
+[[packages]]
+versioned_files = ["Cargo.toml"]
+changelog = "CHANGELOG.md"
+
+[[workflows]]
+name = "prerelease"
+
+[[workflows.steps]]
+type = "PrepareRelease"

--- a/tests/prepare_release/override_prerelease_label/CHANGELOG.md
+++ b/tests/prepare_release/override_prerelease_label/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.1.0
+
+### Features
+
+- New feature in existing release

--- a/tests/prepare_release/override_prerelease_label/Cargo.toml
+++ b/tests/prepare_release/override_prerelease_label/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.1.0"

--- a/tests/prepare_release/override_prerelease_label/EXPECTED_CHANGELOG.md
+++ b/tests/prepare_release/override_prerelease_label/EXPECTED_CHANGELOG.md
@@ -1,0 +1,11 @@
+## 2.0.0-alpha.0
+
+### Breaking Changes
+
+- Breaking feature in new RC
+
+## 1.1.0
+
+### Features
+
+- New feature in existing release

--- a/tests/prepare_release/override_prerelease_label/Expected_Cargo.toml
+++ b/tests/prepare_release/override_prerelease_label/Expected_Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "2.0.0-alpha.0"

--- a/tests/prepare_release/override_prerelease_label/dry_run_output.txt
+++ b/tests/prepare_release/override_prerelease_label/dry_run_output.txt
@@ -1,0 +1,8 @@
+Would bump version to 2.0.0-alpha.1
+Would add the following to CHANGELOG.md: 
+## 2.0.0-alpha.1
+
+### Breaking Changes
+
+- Breaking feature in new RC
+

--- a/tests/prepare_release/override_prerelease_label/knope.toml
+++ b/tests/prepare_release/override_prerelease_label/knope.toml
@@ -1,0 +1,10 @@
+[[packages]]
+versioned_files = ["Cargo.toml"]
+changelog = "CHANGELOG.md"
+
+[[workflows]]
+name = "prerelease"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+prerelease_label = "rc"


### PR DESCRIPTION
Closes #241