### PR TITLE
feat: Support limiting commits to scopes per package.

### DIFF
--- a/docs/src/config/packages.md
+++ b/docs/src/config/packages.md
@@ -20,10 +20,6 @@ If you have multiple packages, you define them like this:
 ```
 
 ```admonish warning
-All conventional commits [currently affect all packages](https://github.com/knope-dev/knope/issues/154). Each package can have its own version, but they will all be updated with the same [semantic versioning] rule together.
-```
-
-```admonish warning
 There used to be an older `[[packages]]` syntax. This is deprecated and will be removed in a future version. Please run `knope --upgrade` to upgrade your configuration automatically.
 ```
 
@@ -33,6 +29,7 @@ Each package, whether it's defined in the `[package]` section or in the `[packag
 
 1. `versioned_files` is an optional array of files you'd like to bump the version of. They all must have the same version—as a package only has one version.
 2. `changelog` is the (optional) Markdown file you'd like to add release notes to.
+3. `scopes` is an optional array of [conventional commit scopes] which should be considered for the package when running the [`PrepareRelease`] step.
 
 ### `versioned_files`
 
@@ -115,3 +112,4 @@ See [`PrepareRelease`] and [`Release`] for details on what happens when those st
 [`command`]: ./step/Command.md
 [request it as a feature]: https://github.com/knope-dev/knope/issues
 [semantic versioning]: https://semver.org
+[conventional commit scopes]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope

--- a/docs/src/config/step/PrepareRelease.md
+++ b/docs/src/config/step/PrepareRelease.md
@@ -12,7 +12,15 @@ The last "version tag" is used as the starting point to read commits—that's th
 
 ## Limitations
 
-The CHANGELOG format is pretty strict. Only three sections will be added to the new version, `### Breaking Changes` for anything that conventional commits have marked as breaking, `### Fixes` for anything called `fix:`, and `### Features` for anything with `feat: `. Any other commits (conventional or not) will be left out. A new version will **always** be generated though, even if there are no changes to record.
+The CHANGELOG format is pretty strict. Only three sections will be added to the new version, `### Breaking Changes` for anything that conventional commits have marked as breaking, `### Fixes` for anything called `fix:`, and `### Features` for anything with `feat: `. Any other commits (conventional or not) will be left out.
+
+## Commit Scopes
+
+The `PrepareRelease` step can be fine-tuned when working with multiple packages to only apply a commit to a specific package's version & changelog. This is done by adding a `scopes` array to the [packages] config and adding a [conventional commit scope] to the commits that should not apply to all packages. The following rules apply, in order, with respect to conventional commit scopes:
+
+1. If no packages define `scopes` in their config, all commits apply to all packages. Scopes are not considered by `knope`.
+2. If a commit does not have a scope, it applies to all packages.
+3. If a commit has a scope, and _any_ package has defined a `scopes` array, the commit will only apply to those packages which have that scope defined in their `scopes` array.
 
 ## Examples
 
@@ -81,15 +89,78 @@ Now you're ready to release 2.0.0—the version that's going to come after 2.0.0
 - A bug in the first `rc` that we fixed.
 ```
 
+### Multiple Packages with Scopes
+
+Here's a `knope` config with two packages: `cli` and `lib`.
+
+```toml
+[package.cli]
+versioned_files = ["cli/Cargo.toml"]
+changelog = "cli/CHANGELOG.md"
+scopes = ["cli"]
+
+[package.lib]
+versioned_files = ["lib/Cargo.toml"]
+changelog = "lib/CHANGELOG.md"
+scopes = ["lib"]
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+```
+
+The `cli` package depends on the `lib` package, so they will likely change together. Let's say the version of `cli` is 1.0.0 and the version of `lib` is 0.8.9. We add the following commits:
+
+1. `feat(cli): Add a new --help option to display usage and exit`
+2. `feat(lib)!: Change the error type of the parse function`
+3. `fix: Prevent a crash when parsing invalid input`
+
+The first two commits are scoped—they will only apply to the packages which have those scopes defined in their `scopes` array. The third commit is not scoped, so it will apply to both packages.
+
+```admonish note
+Here, the configured scopes are the same a the name of the package. This is common, but not required.
+```
+
+When the `release` workflow is run, the `cli` package will be bumped to 1.1.0 and the `lib` package will be bumped to 0.9.0. The changelog for `cli` will look like this:
+
+```md
+## 1.1.0
+
+### Features
+
+- Add a new --help option to display usage and exit
+
+### Fixes
+
+- Prevent a crash when parsing invalid input
+```
+
+And the changelog for `lib` will look like this:
+
+```md
+## 0.9.0
+
+### Breaking Changes
+
+- Change the error type of the parse function
+
+### Fixes
+
+- Prevent a crash when parsing invalid input
+```
+
 ## Errors
 
 The reasons this can fail:
 
-1. If there is no previous tag to base changes off of.
-2. The version could not be bumped for some reason.
-3. The [packages] section is not configured correctly.
+1. The version could not be bumped for some reason.
+2. The [packages] section is not configured correctly.
+3. There was nothing to release. In this case it exits immediately so that there aren't problems with later steps.
 
 [semantic versioning]: https://semver.org
 [bumpversion]: ./BumpVersion.md
 [packages]: ../packages.md
 [`release`]: ./Release.md
+[conventional commit scope]: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope

--- a/src/command.rs
+++ b/src/command.rs
@@ -138,6 +138,7 @@ mod test_replace_variables {
             versioned_files: vec![PathBuf::from("Cargo.toml").try_into().unwrap()],
             changelog: Some(PathBuf::from("CHANGELOG.md").try_into().unwrap()),
             name: None,
+            scopes: None,
         }]
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,8 @@ pub(crate) struct Package {
     pub(crate) versioned_files: Vec<PathBuf>,
     /// The path to the `CHANGELOG.md` file (if any) to be updated when running [`crate::Step::PrepareRelease`].
     pub(crate) changelog: Option<PathBuf>,
+    /// Optional scopes that can be used to filter commits when running [`crate::Step::PrepareRelease`].
+    pub(crate) scopes: Option<Vec<String>>,
 }
 
 /// Generate a brand new config file for the project in the current directory.

--- a/src/releases/package.rs
+++ b/src/releases/package.rs
@@ -16,6 +16,7 @@ pub(crate) struct Package {
     pub(crate) versioned_files: Vec<VersionedFile>,
     pub(crate) changelog: Option<Changelog>,
     pub(crate) name: Option<String>,
+    pub(crate) scopes: Option<Vec<String>>,
 }
 
 impl Package {
@@ -30,6 +31,7 @@ impl Package {
             versioned_files,
             changelog,
             name,
+            scopes: config.scopes,
         })
     }
 }
@@ -204,6 +206,7 @@ pub(crate) fn find_packages() -> Option<PackageConfig> {
     Some(PackageConfig {
         versioned_files,
         changelog,
+        scopes: None,
     })
 }
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -144,6 +144,13 @@ pub(super) enum StepError {
         url("https://knope-dev.github.io/knope/config/step/BumpVersion.html#pre")
     )]
     InvalidPreReleaseVersion(String),
+    #[error("No packages are ready to release")]
+    #[diagnostic(
+        code(step::no_release),
+        help("The `PrepareRelease` step will not complete if no commits cause a package's version to be increased."),
+        url("https://knope-dev.github.io/knope/config/step/PrepareRelease.html"),
+    )]
+    NoRelease,
     #[error("Found invalid semantic version {0}")]
     #[diagnostic(
         code(step::invalid_semantic_version),

--- a/tests/git_release/dry_run_output.txt
+++ b/tests/git_release/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0
 Would add the following to CHANGELOG.md: 
 ## 1.1.0
 

--- a/tests/git_release/multiple_packages/dry_run_output.txt
+++ b/tests/git_release/multiple_packages/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0
+Would bump first version to 2.0.0
 Would add the following to FIRST_CHANGELOG.md: 
 ## 2.0.0
 
@@ -6,7 +6,7 @@ Would add the following to FIRST_CHANGELOG.md:
 
 - New breaking feature
 
-Would bump version to 0.5.0
+Would bump second version to 0.5.0
 Would add the following to SECOND_CHANGELOG.md: 
 ## 0.5.0
 

--- a/tests/prepare_release/changelog_selection/dry_run_output_CHANGELOG.md.txt
+++ b/tests/prepare_release/changelog_selection/dry_run_output_CHANGELOG.md.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0
 Would add the following to CHANGELOG.md: 
 ## 1.1.0
 

--- a/tests/prepare_release/changelog_selection/dry_run_output_CHANGES.md.txt
+++ b/tests/prepare_release/changelog_selection/dry_run_output_CHANGES.md.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0
 Would add the following to CHANGES.md: 
 ## 1.1.0
 

--- a/tests/prepare_release/changelog_selection/dry_run_output_None.txt
+++ b/tests/prepare_release/changelog_selection/dry_run_output_None.txt
@@ -1,1 +1,1 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0

--- a/tests/prepare_release/enable_prerelease/dry_run_output.txt
+++ b/tests/prepare_release/enable_prerelease/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0-rc.1
+Would bump package version to 2.0.0-rc.1
 Would add the following to CHANGELOG.md: 
 ## 2.0.0-rc.1
 

--- a/tests/prepare_release/go_modules/1.1_dry_run_output.txt
+++ b/tests/prepare_release/go_modules/1.1_dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0
 Would add the following to CHANGELOG.md: 
 ## 1.1.0
 

--- a/tests/prepare_release/go_modules/2.0_dry_run_output.txt
+++ b/tests/prepare_release/go_modules/2.0_dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0
+Would bump package version to 2.0.0
 Would add the following to CHANGELOG.md: 
 ## 2.0.0
 

--- a/tests/prepare_release/multiple_packages/dry_run_output.txt
+++ b/tests/prepare_release/multiple_packages/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0
+Would bump first version to 2.0.0
 Would add the following to FIRST_CHANGELOG.md: 
 ## 2.0.0
 
@@ -6,7 +6,7 @@ Would add the following to FIRST_CHANGELOG.md:
 
 - New breaking feature
 
-Would bump version to 0.5.0
+Would bump second version to 0.5.0
 Would add the following to SECOND_CHANGELOG.md: 
 ## 0.5.0
 

--- a/tests/prepare_release/no_version_change/CHANGELOG.md
+++ b/tests/prepare_release/no_version_change/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.0
+
+### Features
+
+- Existing features

--- a/tests/prepare_release/no_version_change/Cargo.toml
+++ b/tests/prepare_release/no_version_change/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.2.3"

--- a/tests/prepare_release/no_version_change/EXPECTED_CHANGELOG.md
+++ b/tests/prepare_release/no_version_change/EXPECTED_CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.0
+
+### Features
+
+- Existing features

--- a/tests/prepare_release/no_version_change/actual_output.txt
+++ b/tests/prepare_release/no_version_change/actual_output.txt
@@ -1,0 +1,9 @@
+Error: 
+  × Problem with workflow release
+
+Error: step::no_release (https://knope-dev.github.io/knope/config/step/PrepareRelease.html)
+
+  × No packages are ready to release
+  help: The `PrepareRelease` step will not complete if no commits cause a
+        package's version to be increased.
+

--- a/tests/prepare_release/no_version_change/dry_run_output.txt
+++ b/tests/prepare_release/no_version_change/dry_run_output.txt
@@ -1,0 +1,9 @@
+Error: 
+  × Problem with workflow release
+
+Error: step::no_release (https://knope-dev.github.io/knope/config/step/PrepareRelease.html)
+
+  × No packages are ready to release
+  help: The `PrepareRelease` step will not complete if no commits cause a
+        package's version to be increased.
+

--- a/tests/prepare_release/no_version_change/knope.toml
+++ b/tests/prepare_release/no_version_change/knope.toml
@@ -1,0 +1,12 @@
+[package]
+versioned_files = ["Cargo.toml"]
+changelog = "CHANGELOG.md"
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Release"

--- a/tests/prepare_release/no_versioned_files/dry_run_output.txt
+++ b/tests/prepare_release/no_versioned_files/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0
 Would add the following to CHANGELOG.md: 
 ## 1.1.0
 

--- a/tests/prepare_release/override_prerelease_label/dry_run_output.txt
+++ b/tests/prepare_release/override_prerelease_label/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0-alpha.1
+Would bump package version to 2.0.0-alpha.1
 Would add the following to CHANGELOG.md: 
 ## 2.0.0-alpha.1
 

--- a/tests/prepare_release/package_selection/dry_run_output.txt
+++ b/tests/prepare_release/package_selection/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0
+Would bump package version to 1.1.0
 Would add the following to CHANGELOG.md: 
 ## 1.1.0
 

--- a/tests/prepare_release/prerelease_after_release/dry_run_output.txt
+++ b/tests/prepare_release/prerelease_after_release/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0-rc.1
+Would bump package version to 2.0.0-rc.1
 Would add the following to CHANGELOG.md: 
 ## 2.0.0-rc.1
 

--- a/tests/prepare_release/release_after_prerelease/dry_run_output.txt
+++ b/tests/prepare_release/release_after_prerelease/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 2.0.0
+Would bump package version to 2.0.0
 Would add the following to CHANGELOG.md: 
 ## 2.0.0
 

--- a/tests/prepare_release/scopes/no_scopes/Cargo.toml
+++ b/tests/prepare_release/scopes/no_scopes/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.0.0"

--- a/tests/prepare_release/scopes/no_scopes/EXPECTED_Cargo.toml
+++ b/tests/prepare_release/scopes/no_scopes/EXPECTED_Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "2.0.0"

--- a/tests/prepare_release/scopes/no_scopes/EXPECTED_FIRST_CHANGELOG.md
+++ b/tests/prepare_release/scopes/no_scopes/EXPECTED_FIRST_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 2.0.0
+
+### Breaking Changes
+
+- New breaking feature with a scope
+
+### Features
+
+- No scope feature

--- a/tests/prepare_release/scopes/no_scopes/EXPECTED_SECOND_CHANGELOG.md
+++ b/tests/prepare_release/scopes/no_scopes/EXPECTED_SECOND_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+### Breaking Changes
+
+- New breaking feature with a scope
+
+### Features
+
+- No scope feature

--- a/tests/prepare_release/scopes/no_scopes/EXPECTED_pyproject.toml
+++ b/tests/prepare_release/scopes/no_scopes/EXPECTED_pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.2.0"

--- a/tests/prepare_release/scopes/no_scopes/dry_run_output.txt
+++ b/tests/prepare_release/scopes/no_scopes/dry_run_output.txt
@@ -1,0 +1,24 @@
+Would bump first version to 2.0.0
+Would add the following to FIRST_CHANGELOG.md: 
+## 2.0.0
+
+### Breaking Changes
+
+- New breaking feature with a scope
+
+### Features
+
+- No scope feature
+
+Would bump second version to 0.2.0
+Would add the following to SECOND_CHANGELOG.md: 
+## 0.2.0
+
+### Breaking Changes
+
+- New breaking feature with a scope
+
+### Features
+
+- No scope feature
+

--- a/tests/prepare_release/scopes/no_scopes/knope.toml
+++ b/tests/prepare_release/scopes/no_scopes/knope.toml
@@ -1,0 +1,13 @@
+[packages.first]
+versioned_files = ["Cargo.toml"]
+changelog = "FIRST_CHANGELOG.md"
+
+[packages.second]
+versioned_files = ["pyproject.toml"]
+changelog = "SECOND_CHANGELOG.md"
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"

--- a/tests/prepare_release/scopes/no_scopes/pyproject.toml
+++ b/tests/prepare_release/scopes/no_scopes/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.1.0"

--- a/tests/prepare_release/scopes/shared_commits/Cargo.toml
+++ b/tests/prepare_release/scopes/shared_commits/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.0.0"

--- a/tests/prepare_release/scopes/shared_commits/EXPECTED_Cargo.toml
+++ b/tests/prepare_release/scopes/shared_commits/EXPECTED_Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.1.0"

--- a/tests/prepare_release/scopes/shared_commits/EXPECTED_FIRST_CHANGELOG.md
+++ b/tests/prepare_release/scopes/shared_commits/EXPECTED_FIRST_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 1.1.0
+
+### Features
+
+- Shared feat
+
+### Fixes
+
+- Fix for first only

--- a/tests/prepare_release/scopes/shared_commits/EXPECTED_SECOND_CHANGELOG.md
+++ b/tests/prepare_release/scopes/shared_commits/EXPECTED_SECOND_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+### Breaking Changes
+
+- Breaking change for second only
+
+### Features
+
+- Shared feat

--- a/tests/prepare_release/scopes/shared_commits/EXPECTED_pyproject.toml
+++ b/tests/prepare_release/scopes/shared_commits/EXPECTED_pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.2.0"

--- a/tests/prepare_release/scopes/shared_commits/dry_run_output.txt
+++ b/tests/prepare_release/scopes/shared_commits/dry_run_output.txt
@@ -1,0 +1,24 @@
+Would bump first version to 1.1.0
+Would add the following to FIRST_CHANGELOG.md: 
+## 1.1.0
+
+### Features
+
+- Shared feat
+
+### Fixes
+
+- Fix for first only
+
+Would bump second version to 0.2.0
+Would add the following to SECOND_CHANGELOG.md: 
+## 0.2.0
+
+### Breaking Changes
+
+- Breaking change for second only
+
+### Features
+
+- Shared feat
+

--- a/tests/prepare_release/scopes/shared_commits/knope.toml
+++ b/tests/prepare_release/scopes/shared_commits/knope.toml
@@ -1,0 +1,15 @@
+[packages.first]
+versioned_files = ["Cargo.toml"]
+changelog = "FIRST_CHANGELOG.md"
+scopes = ["first", "both"]
+
+[packages.second]
+versioned_files = ["pyproject.toml"]
+changelog = "SECOND_CHANGELOG.md"
+scopes = ["second", "both"]
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"

--- a/tests/prepare_release/scopes/shared_commits/pyproject.toml
+++ b/tests/prepare_release/scopes/shared_commits/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.1.0"

--- a/tests/prepare_release/scopes/skip_unchanged_packages/Cargo.toml
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.0.0"

--- a/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_Cargo.toml
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.0.1"

--- a/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_FIRST_CHANGELOG.md
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_FIRST_CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1
+
+### Fixes
+
+- Fix for first only

--- a/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_SECOND_CHANGELOG.md
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_SECOND_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+### Breaking Changes
+
+- Breaking change for second only
+
+### Features
+
+- No-scope feat

--- a/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_pyproject.toml
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/EXPECTED_pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.1.0"

--- a/tests/prepare_release/scopes/skip_unchanged_packages/dry_run_output.txt
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/dry_run_output.txt
@@ -1,0 +1,8 @@
+Would bump first version to 1.0.1
+Would add the following to FIRST_CHANGELOG.md: 
+## 1.0.1
+
+### Fixes
+
+- Fix for first only
+

--- a/tests/prepare_release/scopes/skip_unchanged_packages/knope.toml
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/knope.toml
@@ -1,0 +1,15 @@
+[packages.first]
+versioned_files = ["Cargo.toml"]
+changelog = "FIRST_CHANGELOG.md"
+scopes = ["first", "both"]
+
+[packages.second]
+versioned_files = ["pyproject.toml"]
+changelog = "SECOND_CHANGELOG.md"
+scopes = ["second", "both"]
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"

--- a/tests/prepare_release/scopes/skip_unchanged_packages/pyproject.toml
+++ b/tests/prepare_release/scopes/skip_unchanged_packages/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.1.0"

--- a/tests/prepare_release/scopes/unscoped_commits/Cargo.toml
+++ b/tests/prepare_release/scopes/unscoped_commits/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.0.0"

--- a/tests/prepare_release/scopes/unscoped_commits/EXPECTED_Cargo.toml
+++ b/tests/prepare_release/scopes/unscoped_commits/EXPECTED_Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+version = "1.1.0"

--- a/tests/prepare_release/scopes/unscoped_commits/EXPECTED_FIRST_CHANGELOG.md
+++ b/tests/prepare_release/scopes/unscoped_commits/EXPECTED_FIRST_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 1.1.0
+
+### Features
+
+- No-scope feat
+
+### Fixes
+
+- Fix for first only

--- a/tests/prepare_release/scopes/unscoped_commits/EXPECTED_SECOND_CHANGELOG.md
+++ b/tests/prepare_release/scopes/unscoped_commits/EXPECTED_SECOND_CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+### Breaking Changes
+
+- Breaking change for second only
+
+### Features
+
+- No-scope feat

--- a/tests/prepare_release/scopes/unscoped_commits/EXPECTED_pyproject.toml
+++ b/tests/prepare_release/scopes/unscoped_commits/EXPECTED_pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.2.0"

--- a/tests/prepare_release/scopes/unscoped_commits/dry_run_output.txt
+++ b/tests/prepare_release/scopes/unscoped_commits/dry_run_output.txt
@@ -1,0 +1,24 @@
+Would bump first version to 1.1.0
+Would add the following to FIRST_CHANGELOG.md: 
+## 1.1.0
+
+### Features
+
+- No-scope feat
+
+### Fixes
+
+- Fix for first only
+
+Would bump second version to 0.2.0
+Would add the following to SECOND_CHANGELOG.md: 
+## 0.2.0
+
+### Breaking Changes
+
+- Breaking change for second only
+
+### Features
+
+- No-scope feat
+

--- a/tests/prepare_release/scopes/unscoped_commits/knope.toml
+++ b/tests/prepare_release/scopes/unscoped_commits/knope.toml
@@ -1,0 +1,15 @@
+[packages.first]
+versioned_files = ["Cargo.toml"]
+changelog = "FIRST_CHANGELOG.md"
+scopes = ["first", "both"]
+
+[packages.second]
+versioned_files = ["pyproject.toml"]
+changelog = "SECOND_CHANGELOG.md"
+scopes = ["second", "both"]
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"

--- a/tests/prepare_release/scopes/unscoped_commits/pyproject.toml
+++ b/tests/prepare_release/scopes/unscoped_commits/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+version = "0.1.0"

--- a/tests/prepare_release/second_prerelease/dry_run_output.txt
+++ b/tests/prepare_release/second_prerelease/dry_run_output.txt
@@ -1,4 +1,4 @@
-Would bump version to 1.1.0-rc.2
+Would bump package version to 1.1.0-rc.2
 Would add the following to CHANGELOG.md: 
 ## 1.1.0-rc.2
 


### PR DESCRIPTION
Closes #154 

BREAKING CHANGE: `PrepareRelease` will now error if no version-altering changes are detected.