### PR TITLE
fix: Do not error on `--validate` or `--dry-run` when no release will be created for `PrepareRelease`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "knope"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "base64",
  "clap",

--- a/src/releases/conventional_commits.rs
+++ b/src/releases/conventional_commits.rs
@@ -351,14 +351,13 @@ pub(crate) fn update_project_from_conventional_commits(
             state.releases.push(state::Release::Prepared(release));
         }
     }
-    if state.releases.is_empty() {
-        return Err(StepError::NoRelease);
-    }
     if let Some(dry_run_stdout) = dry_run_stdout {
         Ok(RunType::DryRun {
             state,
             stdout: dry_run_stdout,
         })
+    } else if state.releases.is_empty() {
+        Err(StepError::NoRelease)
     } else {
         Ok(RunType::Real(state))
     }

--- a/tests/prepare_release.rs
+++ b/tests/prepare_release.rs
@@ -1204,7 +1204,7 @@ fn no_version_change() {
 
     // Assert.
     dry_run_output
-        .failure()
+        .success()
         .stderr_eq_path(source_path.join("dry_run_output.txt"));
     actual_assert
         .failure()

--- a/tests/prepare_release/no_version_change/dry_run_output.txt
+++ b/tests/prepare_release/no_version_change/dry_run_output.txt
@@ -1,9 +1,0 @@
-Error: 
-  × Problem with workflow release
-
-Error: step::no_release (https://knope-dev.github.io/knope/config/step/PrepareRelease.html)
-
-  × No packages are ready to release
-  help: The `PrepareRelease` step will not complete if no commits cause a
-        package's version to be increased.
-


### PR DESCRIPTION
Closes #263