### PR TITLE
fix: `--dry-run` will no longer report deleting the same changeset twice

### DIFF
--- a/docs/src/content/docs/tutorials/releasing-multiple-packages.mdx
+++ b/docs/src/content/docs/tutorials/releasing-multiple-packages.mdx
@@ -280,7 +280,6 @@ knope release --dry-run
 
 ```text
 Would delete: .changeset/the_cheese_is_now_distributed_more_evenly.md
-Would delete: .changeset/the_cheese_is_now_distributed_more_evenly.md
 Would add the following to pizza/Cargo.toml: 3.14.16
 Would add the following to pizza/CHANGELOG.md:
 ## 3.14.16 (2023-11-11)

--- a/tests/prepare_release/verbose/dry_run_output.txt
+++ b/tests/prepare_release/verbose/dry_run_output.txt
@@ -5,7 +5,6 @@ Getting conventional commits since last release of package second
 Finding all commits since tag second/v0.4.6
 Would delete: .changeset/breaking_change.md
 Would delete: .changeset/feature.md
-Would delete: .changeset/feature.md
 Determining new version for first
 Looking for Git tags matching package name.
 Finding version for Cargo.toml


### PR DESCRIPTION
Closes #635