### PR TITLE
chore: prepare release 0.13.3

### DIFF
--- a/.changeset/support_pubspecyaml_in_versioned_files.md
+++ b/.changeset/support_pubspecyaml_in_versioned_files.md
@@ -1,9 +1,0 @@
----
-default: minor
----
-
-# Support `pubspec.yaml` in `versioned_files`
-
-Knope can now version Dart projects! You can now add a `pubspec.yaml` file to your `package.versioned_files`.
-
-PR #732 closes #731. Thanks @FallenValkyrie!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The results are changes to the current directory, calls to external commands, an
 Notably, anything written to standard output or standard error
 (what you see in the terminal) is _not_ considered part of the public API and may change between any versions.
 
+## 0.13.3 (2023-12-17)
+
+### Features
+
+#### Support `pubspec.yaml` in `versioned_files`
+
+Knope can now version Dart projects! You can now add a `pubspec.yaml` file to your `package.versioned_files`.
+
+PR #732 closes #731. Thanks @FallenValkyrie!
+
 ## 0.13.2 (2023-11-11)
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "knope"
 description = "A command line tool for automating common development tasks"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Dylan Anthony <contact@dylananthony.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This PR was created by Knope. Merging it will create a new release

### Features

#### Support `pubspec.yaml` in `versioned_files`

Knope can now version Dart projects! You can now add a `pubspec.yaml` file to your `package.versioned_files`.

PR #732 closes #731. Thanks @FallenValkyrie!