### PR TITLE
docs: Fix CreatePullRequest documentation 

### DIFF
--- a/docs/src/content/docs/reference/Config File/Steps/create-pull-request.md
+++ b/docs/src/content/docs/reference/Config File/Steps/create-pull-request.md
@@ -37,9 +37,7 @@ name = "create-release-pull-request"
 
 [[workflows.steps]]
 type = "CreatePullRequest"
-
-[workflows.steps.base]
-default = "main"
+base = "main"
 
 [workflows.steps.title]
 template = "chore: Release $version"


### PR DESCRIPTION
I think it's relatively self explanatory when looking at the commit, but here's the TLDR:

The parameters section referred to the `base` property in a `CreatePullRequest` step as a string, 
when the example used a map. I found out about this because knope gives a deserialization error.


