### PR TITLE
docs: Use correct package name for cargo-binstall

### DIFF
--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -17,7 +17,7 @@ Wish you could install Knope from somewhere else? [Open a discussion](https://gi
 <TabItem label="cargo-binstall">
 
 ```sh
-cargo install binstall
+cargo install cargo-binstall
 cargo binstall knope
 ```
 


### PR DESCRIPTION
The docs say to run `cargo install binstall` but this sends a warning to the user:

```
error: This isn't a real crate! You probably want cargo-binstall.
       See <https://github.com/cargo-bins/cargo-binstall>
 --> C:\Users\WayA\.cargo\registry\src\index.crates.io-6f17d22bba15001f\binstall-0.2.0\src\main.rs:1:1
  |
1 | compile_error!("This isn't a real crate! You probably want cargo-binstall.\nSee <https://github.com/cargo-bins/cargo-binstall>");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: could not compile `binstall` (bin "binstall") due to previous error
```