### PR TITLE
fix: re-order change types

### DIFF
--- a/docs/src/content/docs/recipes/customizing-changelogs.md
+++ b/docs/src/content/docs/recipes/customizing-changelogs.md
@@ -121,9 +121,9 @@ Now, when running a [`CreateChangeFile`] step (for example, with `knope document
 
 ```text
 ? What type of change is this?
-  major
-  minor
   patch
+  minor
+  major
 > note
 [↑↓ to move, enter to select, type to filter]
 ```

--- a/docs/src/content/docs/tutorials/releasing-basic-projects.mdx
+++ b/docs/src/content/docs/tutorials/releasing-basic-projects.mdx
@@ -199,9 +199,9 @@ The terms are from [semantic versioning], so `minor` is what you'll want for a n
 
 ```
 ? What type of change is this?
-  major
-> minor
   patch
+> minor
+  major
 [↑↓ to move, enter to select, type to filter]
 ```
 

--- a/docs/src/content/docs/tutorials/releasing-multiple-packages.mdx
+++ b/docs/src/content/docs/tutorials/releasing-multiple-packages.mdx
@@ -154,9 +154,9 @@ Next, select `patch` as the change type for each:
 > Which packages does this change affect? pizza, calzone
 > What type of change is this for pizza? patch
 ? What type of change is this for calzone?
-  major
-  minor
 > patch
+  minor
+  major
 [↑↓ to move, enter to select, type to filter]
 ```
 

--- a/src/step/releases/package.rs
+++ b/src/step/releases/package.rs
@@ -230,16 +230,16 @@ impl Default for ChangelogSections {
     fn default() -> Self {
         let mut changelog_sections = IndexMap::new();
         changelog_sections.insert(
-            ChangelogSectionSource::CustomChangeType(CustomChangeType::from("major")),
-            ChangeLogSectionName::from("Breaking Changes"),
+            ChangelogSectionSource::CustomChangeType(CustomChangeType::from("patch")),
+            ChangeLogSectionName::from("Fixes"),
         );
         changelog_sections.insert(
             ChangelogSectionSource::CustomChangeType(CustomChangeType::from("minor")),
             ChangeLogSectionName::from("Features"),
         );
         changelog_sections.insert(
-            ChangelogSectionSource::CustomChangeType(CustomChangeType::from("patch")),
-            ChangeLogSectionName::from("Fixes"),
+            ChangelogSectionSource::CustomChangeType(CustomChangeType::from("major")),
+            ChangeLogSectionName::from("Breaking Changes"),
         );
         changelog_sections.insert(CommitFooter::from("Changelog-Note").into(), "Notes".into());
         Self(changelog_sections)


### PR DESCRIPTION
Closes #916 by reordering the change types:

```
? What type of change is this?  
> patch
  minor
  major
  docs
```