### PR TITLE
docs: Use correct package name for cargo-binstall

### DIFF
--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -94,7 +94,7 @@ choco install knope
 <TabItem label="cargo-binstall">
 
 ```sh
-cargo install binstall
+cargo install cargo-binstall
 cargo binstall knope
 ```
 
@@ -132,7 +132,7 @@ cargo install knope
 <TabItem label="cargo-binstall">
 
 ```sh
-cargo install binstall
+cargo install cargo-binstall
 cargo binstall knope
 ```
 


### PR DESCRIPTION
Looks like my previous PR <https://github.com/knope-dev/knope/pull/915> didn't also fix the docs for Windows and Linux 🫠

This new PR addreses that