### PR TITLE
feat: Implement a way to load configuration recursively from parent

### DIFF
--- a/docs/src/content/docs/reference/Config File/Steps/command.md
+++ b/docs/src/content/docs/reference/Config File/Steps/command.md
@@ -27,3 +27,9 @@ and the value is one of the [available variables](/reference/config-file/variabl
 **Take care when selecting a key to replace** as Knope will replace _any_ matching string that it finds.
 Replacements occur in the order they're declared in the config,
 so Knope may replace earlier substitutions with later ones.
+
+## Working directory
+
+By default, the command will be run from the current working directory.
+If you want to run the command from the directory of the first config file in the ancestry of the current working directory,
+you can set the `use_working_directory` attribute to `false`.

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -71,6 +71,9 @@ pub(crate) enum Step {
         /// A map of value-to-replace to [Variable][`crate::command::Variable`] to replace
         /// it with.
         variables: Option<IndexMap<String, Variable>>,
+        /// Whether to run the command in the current working directory or the directory of the config file.
+        /// If not set, the command will be run in the current working directory.
+        use_working_directory: Option<bool>,
     },
     /// This will look through all commits since the last tag and parse any
     /// [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) it finds. It will
@@ -110,9 +113,11 @@ impl Step {
             Step::SwitchBranches => git::switch_branches(run_type)?,
             Step::RebaseBranch { to } => git::rebase_branch(&to, run_type)?,
             Step::BumpVersion(rule) => releases::bump_version(run_type, &rule)?,
-            Step::Command { command, variables } => {
-                command::run_command(run_type, command, variables)?
-            }
+            Step::Command {
+                command,
+                variables,
+                use_working_directory,
+            } => command::run_command(run_type, command, variables, use_working_directory)?,
             Step::PrepareRelease(prepare_release) => {
                 releases::prepare_release(run_type, &prepare_release)?
             }


### PR DESCRIPTION
Closes #72 

This pull request allows knope to recursively search parent directories for a `knope.toml` file, using the contents of the configuration if found.

An additional option is added and documented for the `Command` workflow step type;

- use_working_directory

This option controls whether to run the command in the current working directory that the user is in, or alternatively if set to `false` the first found configuration file in the ancestry path.

⚠️ Some additional work is still required to assure this is fully working.

# Known issues

- [ ] `knope.toml#package.versioned_files` attempts to load from the current working directory, rather than the relative path of the configuration file