### PR TITLE
feat: Add confirm step type

### DIFF
--- a/crates/knope/src/prompt.rs
+++ b/crates/knope/src/prompt.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use inquire::{InquireError, Password, Select};
+use inquire::{Confirm, InquireError, Password, Select};
 use miette::{Diagnostic, Result};
 
 pub(crate) fn select<T: Display>(items: Vec<T>, prompt: &str) -> Result<T, Error> {
@@ -11,6 +11,13 @@ pub(crate) fn get_input(prompt: &str) -> Result<String, Error> {
     Password::new(prompt)
         .with_display_toggle_enabled()
         .without_confirmation()
+        .prompt()
+        .map_err(Error)
+}
+
+pub(crate) fn confirm(prompt: &str) -> Result<bool, Error> {
+    Confirm::new(prompt)
+        .with_default(true)
         .prompt()
         .map_err(Error)
 }

--- a/crates/knope/src/step/confirm.rs
+++ b/crates/knope/src/step/confirm.rs
@@ -1,7 +1,6 @@
-use inquire::Confirm;
 use miette::Diagnostic;
 
-use crate::{app_config, RunType};
+use crate::{prompt, RunType};
 
 pub(crate) fn confirm(
     mut run_type: RunType,
@@ -21,12 +20,12 @@ pub(crate) fn confirm(
         return Ok(run_type);
     }
 
-    let confirmation = Confirm::new(message).with_default(true).prompt();
+    let confirmation = prompt::confirm(message)?;
 
-    match confirmation {
-        Ok(true) => Ok(run_type),
-        Ok(false) => Err(Error::Confirm),
-        Err(err) => Err(Error::Prompt(err)),
+    if confirmation {
+        Ok(run_type)
+    } else {
+        Err(Error::Confirm)
     }
 }
 
@@ -34,11 +33,9 @@ pub(crate) fn confirm(
 pub(crate) enum Error {
     #[error("User did not confirm")]
     Confirm,
-    #[error(transparent)]
-    Prompt(#[from] inquire::InquireError),
     #[error("Unable to write to stdout: {0}")]
     Stdout(#[from] std::io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    AppConfig(#[from] app_config::Error),
+    Prompt(#[from] prompt::Error),
 }

--- a/crates/knope/src/step/confirm.rs
+++ b/crates/knope/src/step/confirm.rs
@@ -3,7 +3,14 @@ use miette::Diagnostic;
 
 use crate::{app_config, RunType};
 
-pub(crate) fn confirm(mut run_type: RunType, message: &str) -> Result<RunType, Error> {
+pub(crate) fn confirm(
+    mut run_type: RunType,
+    message: &str,
+    assume_yes: bool,
+) -> Result<RunType, Error> {
+    if assume_yes {
+        return Ok(run_type);
+    }
     let (_, dry_run_stdout) = match &mut run_type {
         RunType::DryRun { state, stdout } => (state, Some(stdout)),
         RunType::Real(state) => (state, None),

--- a/crates/knope/src/step/confirm.rs
+++ b/crates/knope/src/step/confirm.rs
@@ -1,0 +1,37 @@
+use inquire::Confirm;
+use miette::Diagnostic;
+
+use crate::{app_config, RunType};
+
+pub(crate) fn confirm(mut run_type: RunType, message: &str) -> Result<RunType, Error> {
+    let (_, dry_run_stdout) = match &mut run_type {
+        RunType::DryRun { state, stdout } => (state, Some(stdout)),
+        RunType::Real(state) => (state, None),
+    };
+
+    if let Some(stdout) = dry_run_stdout {
+        writeln!(stdout, "Would prompt for the following message {message}")?;
+        return Ok(run_type);
+    }
+
+    let confirmation = Confirm::new(message).with_default(true).prompt();
+
+    match confirmation {
+        Ok(true) => Ok(run_type),
+        Ok(false) => Err(Error::Confirm),
+        Err(err) => Err(Error::Prompt(err)),
+    }
+}
+
+#[derive(Debug, Diagnostic, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("User did not confirm")]
+    Confirm,
+    #[error(transparent)]
+    Prompt(#[from] inquire::InquireError),
+    #[error("Unable to write to stdout: {0}")]
+    Stdout(#[from] std::io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    AppConfig(#[from] app_config::Error),
+}

--- a/crates/knope/src/step/mod.rs
+++ b/crates/knope/src/step/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 pub mod command;
+pub mod confirm;
 mod create_pull_request;
 pub mod issues;
 pub mod releases;
@@ -95,6 +96,8 @@ pub(crate) enum Step {
         title: Template,
         body: Template,
     },
+    /// Prompt the user to confirm the next step.
+    Confirm { message: String },
 }
 
 impl Step {
@@ -127,6 +130,7 @@ impl Step {
             Step::CreatePullRequest { base, title, body } => {
                 create_pull_request::run(&base, title, body, run_type)?
             }
+            Step::Confirm { message } => confirm::confirm(run_type, message.as_str())?,
         })
     }
 
@@ -167,6 +171,9 @@ pub(super) enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     CreatePullRequest(#[from] create_pull_request::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Confirm(#[from] confirm::Error),
 }
 
 /// The inner content of a [`Step::PrepareRelease`] step.

--- a/crates/knope/src/step/mod.rs
+++ b/crates/knope/src/step/mod.rs
@@ -101,7 +101,7 @@ pub(crate) enum Step {
 }
 
 impl Step {
-    pub(crate) fn run(self, run_type: RunType) -> Result<RunType, Error> {
+    pub(crate) fn run(self, run_type: RunType, assume_yes: bool) -> Result<RunType, Error> {
         Ok(match self {
             Step::SelectJiraIssue { status } => issues::jira::select_issue(&status, run_type)?,
             Step::TransitionJiraIssue { status } => {
@@ -130,7 +130,7 @@ impl Step {
             Step::CreatePullRequest { base, title, body } => {
                 create_pull_request::run(&base, title, body, run_type)?
             }
-            Step::Confirm { message } => confirm::confirm(run_type, message.as_str())?,
+            Step::Confirm { message } => confirm::confirm(run_type, message.as_str(), assume_yes)?,
         })
     }
 

--- a/crates/knope/src/workflow.rs
+++ b/crates/knope/src/workflow.rs
@@ -61,9 +61,9 @@ pub struct Error {
 }
 
 /// Run a series of [`Step`], each of which updates `state`.
-pub(crate) fn run(workflow: Workflow, mut state: RunType) -> Result<(), Error> {
+pub(crate) fn run(workflow: Workflow, mut state: RunType, assume_yes: bool) -> Result<(), Error> {
     for step in workflow.steps {
-        state = match step.run(state) {
+        state = match step.run(state, assume_yes) {
             Ok(state) => state,
             Err(err) => {
                 return Err(Error {
@@ -90,6 +90,7 @@ pub(crate) fn validate(
                     state: state.clone(),
                     stdout: Box::new(sink()),
                 },
+                false,
             )
             .err()
         })

--- a/crates/knope/tests/default_workflows/document_change/stdout.log
+++ b/crates/knope/tests/default_workflows/document_change/stdout.log
@@ -1,7 +1,8 @@
 Usage: knope[EXE] document-change [OPTIONS]
 
 Options:
-      --dry-run  Pretend to run a workflow, outputting what _would_ happen without actually doing it.
-  -v, --verbose  Print extra information (for debugging)
-  -h, --help     Print help
-  -V, --version  Print version
+      --dry-run    Pretend to run a workflow, outputting what _would_ happen without actually doing it.
+  -y, --assumeyes  Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively.
+  -v, --verbose    Print extra information (for debugging)
+  -h, --help       Print help
+  -V, --version    Print version

--- a/crates/knope/tests/default_workflows/release/help_multi_package/stdout.log
+++ b/crates/knope/tests/default_workflows/release/help_multi_package/stdout.log
@@ -7,6 +7,8 @@ Options:
           Override the version set by `BumpVersion` or `PrepareRelease` for multiple packages. Format is like package_name=version, can be set multiple times.
       --prerelease-label <prerelease-label>
           Set the `prerelease_label` attribute of any `PrepareRelease` steps at runtime. [env: KNOPE_PRERELEASE_LABEL=]
+  -y, --assumeyes
+          Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively.
   -v, --verbose
           Print extra information (for debugging)
   -h, --help

--- a/crates/knope/tests/default_workflows/release/help_single_package/stdout.log
+++ b/crates/knope/tests/default_workflows/release/help_single_package/stdout.log
@@ -7,6 +7,8 @@ Options:
           Override the version set by `BumpVersion` or `PrepareRelease` for the package.
       --prerelease-label <prerelease-label>
           Set the `prerelease_label` attribute of any `PrepareRelease` steps at runtime. [env: KNOPE_PRERELEASE_LABEL=]
+  -y, --assumeyes
+          Automatic yes to prompts. Assume "yes" as answer to all prompts and run non-interactively.
   -v, --verbose
           Print extra information (for debugging)
   -h, --help

--- a/docs/src/content/docs/reference/Config File/Steps/confirm.md
+++ b/docs/src/content/docs/reference/Config File/Steps/confirm.md
@@ -1,0 +1,26 @@
+---
+title: Confirm
+---
+
+Prompt the user to confirm a given message. Approving the prompt will continue to run the workflow.
+Rejecting the prompt will stop the workflow and no further steps will be run.
+
+## Example
+
+```toml
+[[workflows.steps]]
+type = "Confirm"
+message = "Are you sure you want to run the cleanup step?"
+```
+
+The example workflow above will promp the user with the following message:
+
+```shell
+
+? Are you sure you want to run the cleanup step? (Y/n)
+
+```
+
+## Automatic confirmation
+
+If you want to automatically confirm all steps in a workflow, you can run the workflow with either the `--assumeyes` or `-y` flag.

--- a/docs/src/content/docs/reference/command-line-arguments.md
+++ b/docs/src/content/docs/reference/command-line-arguments.md
@@ -71,3 +71,7 @@ producing an error if either of those packages isn't configured.
 
 [`BumpVersion`]: /reference/config-file/steps/bump-version
 [`PrepareRelease`]: /reference/config-file/steps/prepare-release
+
+### `--assumeyes`
+
+Automatically answer all confirmation steps with a "yes". See [`Confirm`](/reference/config-file/steps/confirm/) for more information about the `Confirm` step type.


### PR DESCRIPTION
Closes #953 

Provides functionality to allow prompts with confirmation before proceeding with the remainder of the workflow.

Dry-run functionality will simply print a message saying that it will prompt the users with the message provided in the `knope.toml` configuration.

- [ ] Refactor `confirm` function to make testing easier
- [ ] Add unit tests
- [x] Add documentation for `confirm` step type
- [x] Add auto-confirmation functionality (`-y` in the CLI) 
- [x] Add documentation for `-y` flag