### PR TITLE
docs(typo): Fix typo in config example for multiple packages

### DIFF
--- a/docs/src/content/docs/reference/default-config.md
+++ b/docs/src/content/docs/reference/default-config.md
@@ -60,11 +60,11 @@ version = "0.1.0"
 ```
 
 ```toml title="knope.toml"
-[package.something]
+[packages.something]
 versioned_files = ["member1/Cargo.toml"]
 scopes = ["something"]
 
-[package.something-else]
+[packages.something-else]
 versioned_files = ["member2/Cargo.toml"]
 scopes = ["something-else"]
 ```


### PR DESCRIPTION
**What:**

* Fixes a typo in the config example for multiple packages, renaming `package` to `packages`

**Why:**

An unsuspecting user seeing this project for the first time will copy-and-paste the configuration example, and stumble upon a TOML de-serialize error when using this config example for their own configuration.