### PR TITLE
chore: Remove thiserror@1 from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -112,7 +112,6 @@ skip-tree = [
   { name = "bitflags", version = "1", depth = 1 },         # crossterm, inquire, redox_syscall, etc. all use this
   { name = "windows-sys", version = "0.48", depth = 5 },   # inquire requires an old version of crossterm
   { name = "windows-sys", version = "0.52", depth = 5 },   # so many things... it'll be a while
-  { name = "thiserror", version = "1.0", depth = 2 },      # Waiting on redox
   { name = "generic-array", version = "0.14", depth = 1 }, # Small dep which will be removed soon
   { name = "getrandom", version = "0.2", depth = 1 },      # Waiting on ring
   { name = "wasi", version = "*", depth = 1 },             # We don't compile for wasi, so don't care


### PR DESCRIPTION
Miette doesn't require it at _all_ anymore!